### PR TITLE
Simplify site into minimal landing page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,52 +1,16 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
-    <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'>
-
-    <title>{% if page.title %}{{ page.title }} – {% endif %}{{ site.name }} – {{ site.description }}</title>
-
-    <meta name="author" content="{{ site.name }}" />
-    <meta name="description" content="{{ site.description }}">
-
-    <!--[if lt IE 9]>
-      <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,700,700italic,400italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/style.css" />
-    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
-
-    <!-- Created with Jekyll Now - http://github.com/barryclark/jekyll-now -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title | default: site.name | default: "Diogo Neves" }}</title>
+    <meta name="description" content="{{ site.description | default: "Diogo is building on YouTube." }}" />
+    <link rel="icon" href="{{ '/favicon.ico' | relative_url }}" />
+    <link rel="stylesheet" href="{{ '/style.css' | relative_url }}" />
   </head>
-
   <body>
-    <div class="wrapper-masthead">
-      <div class="container">
-        <header class="masthead clearfix">
-          <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar }}" /></a>
-
-          <div class="site-info">
-            <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
-            <p class="site-description">{{ site.description }}</p>
-          </div>
-        </header>
-      </div>
-    </div>
-
-    <div id="main" role="main" class="container">
-      {{ content }}
-    </div>
-
-    <div class="wrapper-footer">
-      <div class="container">
-        <footer class="footer">
-          {% include svg-icons.html %}
-        </footer>
-      </div>
-    </div>
-
-    {% include analytics.html %}
+    {{ content }}
+    <script src="{{ '/assets/js/glitch.js' | relative_url }}" defer></script>
   </body>
 </html>

--- a/assets/js/glitch.js
+++ b/assets/js/glitch.js
@@ -1,0 +1,63 @@
+(function () {
+  const target = document.getElementById('glitch-text');
+  if (!target) return;
+
+  // Edit the phrases below to change the animated hacker-style log line.
+  const MESSAGES = [
+    'Analysing YouTube experiments...',
+    'Building tools I actually use...',
+    'Logging every video. Iterating forever...',
+    'Decrypting growth patterns...',
+    'Simulating the next 100 uploads...'
+  ];
+
+  if (!MESSAGES.length) return;
+
+  const DISPLAY_DURATION = 3400;
+  const GLITCH_FRAMES = 10;
+  const FRAME_DURATION = 48;
+  const NOISE_CHARS = '!<>-_/\\[]{}=+*^?#%';
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let index = 0;
+  let timerId;
+
+  const randomChar = () => NOISE_CHARS[Math.floor(Math.random() * NOISE_CHARS.length)] || '#';
+  const noiseString = (length) => Array.from({ length }, randomChar).join('');
+
+  const setMessage = (value) => {
+    target.textContent = value;
+  };
+
+  const glitchTransition = (nextText) => {
+    if (prefersReducedMotion) {
+      setMessage(nextText);
+      return;
+    }
+
+    let frames = 0;
+    const maxNoiseLength = Math.max(10, Math.min(28, nextText.length + 6));
+
+    const intervalId = window.setInterval(() => {
+      frames += 1;
+      setMessage(noiseString(maxNoiseLength));
+
+      if (frames >= GLITCH_FRAMES) {
+        window.clearInterval(intervalId);
+        setMessage(nextText);
+      }
+    }, FRAME_DURATION);
+  };
+
+  const cycleMessages = () => {
+    index = (index + 1) % MESSAGES.length;
+    glitchTransition(MESSAGES[index]);
+    timerId = window.setTimeout(cycleMessages, DISPLAY_DURATION);
+  };
+
+  setMessage(MESSAGES[0]);
+  timerId = window.setTimeout(cycleMessages, DISPLAY_DURATION);
+
+  window.addEventListener('pagehide', () => {
+    window.clearTimeout(timerId);
+  });
+})();

--- a/index.md
+++ b/index.md
@@ -1,39 +1,27 @@
 ---
-layout: page
+layout: default
+title: Diogo Neves
 ---
 
-I am a father of two amazing girls and was, until recently, an **Engineering Manager @ Apple**.  
+<main class="landing" aria-labelledby="hero-text">
+  <section class="hero">
+    <h1 id="hero-text" class="hero-text">
+      Diogo is building on YouTube.
+      <!-- Update the hero sentence above to change the main statement. -->
+    </h1>
+  </section>
 
-I have worked as an engineer on a few different things, from Siri to the 
-_BAFTA award-winning_ **Little Big Planet PSP** and **Killzone Mercenary**, 
-venturing into smaller startups in-between.
+  <section class="glitch-area" aria-live="polite" aria-atomic="true">
+    <span class="mono-prefix">&gt;</span>
+    <span id="glitch-text" class="glitch-text">Loading...</span>
+  </section>
 
-My free time goes mostly to my **lovely family**, enjoying life, or in a dark room at night,
-learning more about whatever is my current interest.
-
-### Curiosities 🌟
-
-* Diving head first in VR/AR industry   
-* Won a [BAFTA as part of the Little Big Planet Team](http://www.bafta.org/games/awards/2010-winners-nominees,2475,BA.html){:target="_blank"}
-* Can't burp
-* Native Portuguese (🇵🇹) and fluent English (🇬🇧)
-* Don't like bullet point lists  
-* Always 🔴 💊  
-
------
-
-### Work 💻
-
-* Worked on awesome stuff @ Siri [Apple](https://www.apple.com/){:target="_blank"} (including getting Siri to run on device)  
-* Developing a new way to Discover Music @
-[LOST](http://lost.am/){:target="_blank"}
-* Fitting bits in small places @ [Icomera](http://www.icomera.com/){:target="_blank"}
-* Developing Games, Experimental Concepts and Technology @
-[Guerrilla Cambridge](http://www.worldwidestudios.net/cambridge){:target="_blank"}
-(ex Sony Cambridge)
-* Developing Facebook applications @ [Wildbunny](http://wildbunny.co.uk/){:target="_blank"}
-(Founder)
-* Smashing bits, developing more games and general crazy person
-@ [Vortix Games Studios](http://blog.vortixgames.com/){:target="_blank"} (Founder)
-* Researching VR, AR and Motion Capture applications for artistic body motion @
-[INESC-ID](http://www.inesc-id.pt/){:target="_blank"}
+  <footer class="footer-links">
+    <a href="https://www.youtube.com/@DiogoSnows" target="_blank" rel="noopener">Watch on YouTube</a>
+    <a href="#docs" target="_blank" rel="noopener">
+      Video docs &amp; notes
+      <!-- Replace #docs with your Notion URL when it's ready. -->
+    </a>
+    <a href="https://github.com/diogoneves" target="_blank" rel="noopener">GitHub</a>
+  </footer>
+</main>

--- a/style.scss
+++ b/style.scss
@@ -1,300 +1,127 @@
 ---
 ---
 
-//
-// IMPORTS
-//
+:root {
+  --bg: #050505;
+  --panel: #0b0b0b;
+  --text: #f7f7f7;
+  --muted: #c4c8cc;
+  --accent: #8fffd1;
+  --glow: rgba(143, 255, 209, 0.2);
+}
 
-@import "_reset";
-@import "_variables";
-// Syntax highlighting @import is at the bottom of this file
-
-/**************/
-/* BASE RULES */
-/**************/
-
-html {
-  font-size: 100%;
-  font-weight: 400;
+* {
+  box-sizing: border-box;
 }
 
 body {
-	background: $white;
-  font: 20px/1.5 $bodyFont;
-  color: $darkGray;
-}
-
-.container {
-  margin: 0 auto;
-  max-width: 740px;
-  padding: 0 10px;
-  width: 100%;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  font-family: $headerFont;
-  color: $darkerGray;
-  font-weight: 700;
-
-  line-height: 1.9;
-  margin: 1em 0 15px;
-  padding: 0;
-
-  @include mobile {
-    line-height: 1.4;
-  }
-}
-
-h1 {
-  font-size: 34px;
-  a {
-    color: inherit;
-  }
-}
-
-h2 {
-  font-size: 26px;
-  font-style: italic;
-}
-
-h3 {
-  font-size: 22px;
-  font-style: italic;
-}
-
-h4 {
-  font-size: 20px;
-  font-style: italic;
-  color: $gray;
-}
-
-sub, sup, small {
-  font-size: smaller;
-}
-
-sup {
-  vertical-align: super;
-}
-
-sub {
-  vertical-align: sub;
-}
-
-p {
-  margin: 15px 0;
-}
-
-a {
-  color: $blue;
-  text-decoration: none;
-	cursor: pointer;
-  &:hover, &:active {
-    color: $blue;
-  }
-}
-
-ul, ol {
-  margin: 15px 0;
-  padding-left: 30px;
-}
-
-ul {
-  list-style-type: disc;
-}
-
-ol {
-  list-style-type: decimal;
-}
-
-ol ul, ul ol, ul ul, ol ol {
   margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.5;
 }
 
-ul ul, ol ul {
-  list-style-type: circle;
-}
-
-em, i {
-  font-style: italic;
-}
-
-strong, b {
-  font-weight: bold;
-}
-
-img {
-  max-width: 100%;
-}
-
-.date {
-  font-style: italic;
-  color: $gray;
-}
-
-// Specify the color of the selection
-::-moz-selection {
-  color: $black;
-  background: $lightGray;
-}
-::selection {
-  color: $black;
-  background: $lightGray;
-}
-
-// Nicolas Gallagher's micro clearfix hack
-// http://nicolasgallagher.com/micro-clearfix-hack/
-.clearfix:before,
-.clearfix:after {
-    content: " ";
-    display: table;
-}
-
-.clearfix:after {
-    clear: both;
-}
-
-/*********************/
-/* LAYOUT / SECTIONS */
-/*********************/
-
-//
-// .masthead
-//
-
-.wrapper-masthead {
-  margin-bottom: 50px;
-}
-
-.masthead {
-  padding: 20px 0;
-  border-bottom: 1px solid $lightGray;
-
-  @include mobile {
-    text-align: center;
-  }
-}
-
-.site-avatar {
-  float: left;
-  width: 70px;
-  height: 70px;
-  margin-right: 15px;
-
-  @include mobile {
-    float: none;
-    display: block;
-    margin: 0 auto;
-  }
-
-  img {
-    border-radius: 5px;
-  }
-}
-
-.site-info {
-  float: left;
-
-  @include mobile {
-    float: none;
-    display: block;
-    margin: 0 auto;
-  }
-}
-
-.site-name {
-  margin: 0;
-  color: $darkGray;
-  cursor: pointer;
-  font-family: $headerFont;
-  font-weight: 300;
-  font-size: 28px;
-  letter-spacing: 1px;
-}
-
-.site-description {
-  margin: -5px 0 0 0;
-  color: $gray;
-  font-size: 16px;
-
-  @include mobile {
-    margin: 3px 0;
-  }
-}
-
-nav {
-  float: right;
-  margin-top: 23px; // @TODO: Vertically middle align
-  font-family: $headerFont;
-  font-size: 18px;
-
-  @include mobile {
-    float: none;
-    margin-top: 9px;
-    display: block;
-    font-size: 16px;
-  }
-
-  a {
-    margin-left: 20px;
-    color: $darkGray;
-    text-align: right;
-    font-weight: 300;
-    letter-spacing: 1px;
-
-    @include mobile {
-      margin: 0 10px;
-      color: $blue;
-    }
-  }
-}
-
-//
-// .main
-//
-
-.posts > .post {
-  padding-bottom: 2em;
-  border-bottom: 1px solid $lightGray;
-}
-
-.posts > .post:last-child {
-  padding-bottom: 1em;
-  border-bottom: none;
-}
-
-.post {
-  blockquote {
-    margin: 1.8em .8em;
-    // border-left: 2px solid $gray;
-    padding: 0.1em 1em;
-    color: $gray;
-    font-size: 22px;
-    font-style: italic;
-    text-align: right;
-  }
-
-  .comments {
-    margin-top: 10px;
-  }
-
-  .read-more {
-    text-transform: uppercase;
-    font-size: 15px;
-  }
-}
-
-.wrapper-footer {
-  margin-top: 50px;
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
-  background-color: $lightGray;
-}
-
-footer {
-  padding: 20px 0;
+main.landing {
+  width: min(960px, 100% - 2.5rem);
+  padding: 2.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2vw, 2.75rem);
   text-align: center;
 }
 
-// Settled on moving the import of syntax highlighting to the bottom of the CSS
-// ... Otherwise it really bloats up the top of the CSS file and makes it difficult to find the start
-@import "_highlights";
+.hero-text {
+  font-size: clamp(2.8rem, 6vw, 4.8rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  margin: 0;
+}
+
+.glitch-area {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 0 auto;
+  padding: 0.9rem 1.2rem;
+  border-radius: 10px;
+  border: 1px solid #1a1a1a;
+  background: var(--panel);
+  box-shadow: 0 0 0 1px #0f0f0f, 0 0 22px var(--glow);
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  color: var(--accent);
+  min-height: 3rem;
+}
+
+.mono-prefix {
+  opacity: 0.6;
+}
+
+.glitch-text {
+  letter-spacing: 0.03em;
+  white-space: pre-wrap;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1.1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin-top: 0.5rem;
+}
+
+.footer-links a {
+  color: var(--text);
+  text-decoration: none;
+  padding-bottom: 2px;
+  border-bottom: 1px solid transparent;
+  transition: opacity 160ms ease, border-color 160ms ease;
+}
+
+.footer-links a:hover,
+.footer-links a:focus-visible {
+  opacity: 0.8;
+  border-color: var(--text);
+  outline: none;
+}
+
+.footer-links a:focus-visible {
+  box-shadow: 0 0 0 2px #1a1a1a, 0 0 0 4px var(--glow);
+  border-radius: 6px;
+  padding: 0.1rem 0.25rem;
+  margin: -0.1rem -0.25rem;
+}
+
+::selection {
+  background: #1f2a1f;
+  color: var(--accent);
+}
+
+@media (max-width: 540px) {
+  main.landing {
+    width: min(960px, 100% - 1.6rem);
+    align-items: center;
+  }
+
+  .footer-links {
+    gap: 0.75rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    scroll-behavior: auto !important;
+    transition: none !important;
+    animation-duration: 0.001ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the default Jekyll layout with a minimal, full-screen landing experience
- update the home page content with the new hero statement, footer links, and glitch log line
- add lightweight styles and JavaScript for the dark terminal aesthetic and animated messages

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69240f990c30832086d1c9de789e5ebb)